### PR TITLE
WebJar CDN path issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ modules                 | The json array of modules.
 optimize                | The name of the optimizer, defaults to uglify2.
 paths                   | A set of RequireJS path mappings. By default all WebJar libraries are made available from a CDN and their mappings can be found here (unless the cdn is set to None).
 preserveLicenseComments | Whether to preserve comments or not. Defaults to false given source maps (see http://requirejs.org/docs/errors.html#sourcemapcomments).
-webjarCdn               | A CDN to be used for locating WebJars. By default jsdelivr is used.
+webJarCdns              | CDNs to be used for locating WebJars. By default "org.webjars" is mapped to "jsdelivr".
 webJarModuleIds         | A sequence of webjar module ids to be used.
 
 Supposing that your application does not use "main.js" as its main entry point and instead uses `app.js`:

--- a/src/sbt-test/sbt-rjs-plugin/rjs/build.sbt
+++ b/src/sbt-test/sbt-rjs-plugin/rjs/build.sbt
@@ -1,3 +1,15 @@
 lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
+libraryDependencies ++= Seq(
+  "org.webjars" % "requirejs" % "2.1.11-1"
+)
+
 pipelineStages := Seq(rjs)
+
+val checkCdn = taskKey[Unit]("Check the CDN")
+
+checkCdn := {
+  if (RjsKeys.paths.value != Map("requirejs" -> "http://cdn.jsdelivr.net/webjars/requirejs/2.1.11-1")) {
+    sys.error(s"${RjsKeys.paths} is not what we expected")
+  }
+}

--- a/src/sbt-test/sbt-rjs-plugin/rjs/test
+++ b/src/sbt-test/sbt-rjs-plugin/rjs/test
@@ -10,3 +10,5 @@ $ exists target/web/stage/javascripts/b.js
 $ exists target/web/stage/javascripts/b.js.map
 $ exists target/web/stage/javascripts/b.js.src.js
 
+> checkCdn
+


### PR DESCRIPTION
As initially reported here: https://github.com/sbt/sbt-web/issues/39

We now avoid the webjar locator for CDN mapping as the version of the WebJar that it returned wasn't the right one for our needs. As a consequence the WebJars were being mapped incorrectly for the CDN.

CDN configuration is also enhanced so it also receives a mapping of WebJar organisations to CDNs. Thus you can now have many CDNs declared.
