### PR TITLE
Unable to get sbt-rjs incremental execution to work without clean

### DIFF
--- a/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
+++ b/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
@@ -55,7 +55,7 @@ object SbtRjs extends AutoPlugin {
     baseUrl := getBaseUrl.value,
     buildProfile := JS.Object.empty,
     buildWriter := getBuildWriter.value,
-    dir := appDir.value / "build",
+    dir := (resourceManaged in rjs).value / "build",
     excludeFilter in rjs := HiddenFileFilter,
     generateSourceMaps := true,
     includeFilter in rjs := GlobFilter("*.js") | GlobFilter("*.css") | GlobFilter("*.map"),
@@ -189,11 +189,10 @@ object SbtRjs extends AutoPlugin {
             (timeoutPerSource in rjs).value * optimizerMappings.size
           )
 
-          appDir.value.***.get.toSet
+          dir.value.***.get.toSet
       }
 
-      val dirStr = dir.value.getAbsolutePath
-      val optimizedMappings = runUpdate(Set(appDir.value)).filter(f => f.isFile && f.getAbsolutePath.startsWith(dirStr)).pair(relativeTo(dir.value))
+      val optimizedMappings = runUpdate(appDir.value.***.get.toSet).filter(_.isFile).pair(relativeTo(dir.value))
       (mappings.toSet -- optimizerMappings.toSet ++ optimizedMappings).toSeq
   }
 


### PR DESCRIPTION
I'm trying to use sbt-rjs in a non-play sbt project.

My `plugins.sbt` includes this:

``` scala
addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.0-RC3")
```

And my `build.sbt` includes this:

``` scala
import RjsKeys._
import WebJs._

lazy val root = (project in file(".")).enablePlugins(SbtWeb)

JsEngineKeys.engineType := JsEngineKeys.EngineType.Node

pipelineStages := Seq(rjs)
```

The first time I invoke `sbt web-stage` everything works perfectly, but on subsequent re-runs nothing happens. The only way I can get the pipeline to run again is if I remove the resulting artifacts from my target directory. So `sbt ~web-stage` won't work, I have to do something like `~;clean; web-stage`.
