### PR TITLE
rjs configuration requires quotes

### DIFF
--- a/sbt-rjs-plugin-tester/src/main/assets/javascripts/main.js
+++ b/sbt-rjs-plugin-tester/src/main/assets/javascripts/main.js
@@ -3,7 +3,7 @@
 requirejs.config({
     paths: {
         'underscore': '../lib/underscorejs/underscore',
-        'myrequire': '../lib/requirejs/require'
+        myrequire: '../lib/requirejs/require'
     },
     shim: {
         'underscore': {

--- a/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
+++ b/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
@@ -133,7 +133,7 @@ object SbtRjs extends AutoPlugin {
       val lib = withSep(webModulesLib.value)
       val config = IO.read(f, Utf8)
       val pathModuleMappings = SortedMap(
-        s"""['"](.*)['"]\\s*:\\s*[\\[]?.*['"].*/$lib(.*)['"]""".r
+        s"""['"]?([^\\s'"]*)['"]?\\s*:\\s*[\\[]?.*['"].*/$lib(.*)['"]""".r
           .findAllIn(config)
           .matchData.map(m => m.subgroups(1) -> m.subgroups(0))
           .toIndexedSeq


### PR DESCRIPTION
The following configuration is valid yet isn't processed by sbt-rjs:

``` javascript
require.config {
  paths: {
    leaflet: "../lib/leaflet/leaflet"
  }
}
```

The problem is that rjs expects `leaflet` to be `"leaflet"` i.e. quoted.
