### PR TITLE
Add r.js's removeCombined option

### DIFF
--- a/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
+++ b/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
@@ -29,6 +29,7 @@ object Import {
     val optimize = SettingKey[String]("rjs-optimize", "The name of the optimizer, defaults to uglify2.")
     val paths = TaskKey[Map[String, (String, String)]]("rjs-paths", "RequireJS path mappings of module ids to a tuple of the build path and production path. By default all WebJar libraries are made available from a CDN and their mappings can be found here (unless the cdn is set to None).")
     val preserveLicenseComments = SettingKey[Boolean]("rjs-preserve-license-comments", "Whether to preserve comments or not. Defaults to false given source maps (see http://requirejs.org/docs/errors.html#sourcemapcomments).")
+    val removeCombined = SettingKey[Boolean]("rjs-remove-combined", "Whether to remove source files. Defaults to true.")
     val webJarCdns = SettingKey[Map[String, String]]("rjs-webjar-cdns", """CDNs to be used for locating WebJars. By default "org.webjars" is mapped to "jsdelivr".""")
   }
 
@@ -66,6 +67,7 @@ object SbtRjs extends AutoPlugin {
     optimize := "uglify2",
     paths := getWebJarPaths.value,
     preserveLicenseComments := false,
+    removeCombined := true,
     resourceManaged in rjs := webTarget.value / rjs.key.label,
     rjs := runOptimizer.dependsOn(webJarsNodeModules in Plugin).value,
     webJarCdns := Map("org.webjars" -> "http://cdn.jsdelivr.net/webjars")
@@ -85,7 +87,8 @@ object SbtRjs extends AutoPlugin {
       "onBuildWrite" -> buildWriter.value,
       "optimize" -> optimize.value,
       "paths" -> paths.value.map(m => m._1 -> "empty:"),
-      "preserveLicenseComments" -> preserveLicenseComments.value
+      "preserveLicenseComments" -> preserveLicenseComments.value,
+      "removeCombined" -> removeCombined.value
     ) ++ buildProfile.value
   }
 

--- a/src/sbt-test/sbt-rjs-plugin/rjs/test
+++ b/src/sbt-test/sbt-rjs-plugin/rjs/test
@@ -3,12 +3,6 @@
 > web-stage
 $ exists target/web/stage/javascripts/main.js
 $ exists target/web/stage/javascripts/main.js.map
-$ exists target/web/stage/javascripts/a.js
-$ exists target/web/stage/javascripts/a.js.map
-$ exists target/web/stage/javascripts/a.js.src.js
-$ exists target/web/stage/javascripts/b.js
-$ exists target/web/stage/javascripts/b.js.map
-$ exists target/web/stage/javascripts/b.js.src.js
 
 > checkCdn
 


### PR DESCRIPTION
This means we need only to uglify the compiled files instead of the compiled files and all source files. Should result in much faster compilation.

angular-seed-play was taking a few minutes to compile previously. I'm guessing that it will be much faster with this change though I haven't tested it
