### PR TITLE
webjar CDN substitution doesn't work if the path keys aren't quoted

### DIFF
--- a/src/sbt-test/sbt-rjs-plugin/rjs/build.sbt
+++ b/src/sbt-test/sbt-rjs-plugin/rjs/build.sbt
@@ -2,7 +2,8 @@ lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
 libraryDependencies ++= Seq(
   "org.webjars" % "requirejs" % "2.1.11-1",
-  "org.webjars" % "underscorejs" % "1.6.0-1"
+  "org.webjars" % "underscorejs" % "1.6.0-1",
+  "org.webjars" % "knockout" % "2.3.0"
 )
 
 pipelineStages := Seq(rjs)
@@ -10,7 +11,10 @@ pipelineStages := Seq(rjs)
 val checkCdn = taskKey[Unit]("Check the CDN")
 
 checkCdn := {
-  if (RjsKeys.paths.value != Map("myunderscore" ->("lib/underscorejs/underscore", "http://cdn.jsdelivr.net/webjars/underscorejs/1.6.0-1/underscore-min"))) {
+  if (RjsKeys.paths.value != Map(
+    "myunderscore" -> ("lib/underscorejs/underscore", "http://cdn.jsdelivr.net/webjars/underscorejs/1.6.0-1/underscore-min"),
+    "myknockout" -> ("lib/knockout/knockout", "http://cdn.jsdelivr.net/webjars/knockout/2.3.0/knockout")
+  )) {
     sys.error(s"${RjsKeys.paths.value} is not what we expected")
   }
 }

--- a/src/sbt-test/sbt-rjs-plugin/rjs/src/main/assets/javascripts/main.js
+++ b/src/sbt-test/sbt-rjs-plugin/rjs/src/main/assets/javascripts/main.js
@@ -1,6 +1,7 @@
 requirejs.config({
     paths: {
-        'myunderscore': '../lib/underscorejs/underscore'
+        'myunderscore': '../lib/underscorejs/underscore',
+        myknockout: '../lib/knockout/knockout'
     },
     shim: {
         'underscore': {


### PR DESCRIPTION
``` js
paths: {
  "jquery": "lib/jquery/jquery"
}
```

will end up using the webjars CDN in production, but

``` js
paths: {
  jquery: "lib/jquery/jquery"
}
```

won't.
