### PR TITLE
WebJar CDN substitution only works for direct dependencies

### DIFF
--- a/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
+++ b/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
@@ -149,7 +149,7 @@ object SbtRjs extends AutoPlugin {
         ifExists(p + ".min").orElse(ifExists(p + "-min")).getOrElse(p)
       }
       val webJarCdnPaths = for {
-        m <- libraryDependencies.value
+        m <- allDependencies(update.value)
         cdn <- webJarCdns.value.get(m.organization)
       } yield for {
           pm <- pathModuleMappings.from(m.name + "/") if pm._1.startsWith(m.name + "/")
@@ -160,6 +160,12 @@ object SbtRjs extends AutoPlugin {
         }
       webJarCdnPaths.flatten.toMap
     }
+  }
+
+  private def allDependencies(updateReport: UpdateReport): Seq[ModuleID] = {
+    updateReport.filter(
+      configurationFilter(Compile.name) && artifactFilter(`type` = "jar")
+    ).toSeq.map(_._2).distinct
   }
 
   private def runOptimizer: Def.Initialize[Task[Pipeline.Stage]] = Def.task {

--- a/src/sbt-test/sbt-rjs-plugin/rjs/build.sbt
+++ b/src/sbt-test/sbt-rjs-plugin/rjs/build.sbt
@@ -3,7 +3,8 @@ lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 libraryDependencies ++= Seq(
   "org.webjars" % "requirejs" % "2.1.11-1",
   "org.webjars" % "underscorejs" % "1.6.0-1",
-  "org.webjars" % "knockout" % "2.3.0"
+  "org.webjars" % "knockout" % "2.3.0",
+  "org.webjars" % "bootstrap" % "3.2.0"
 )
 
 pipelineStages := Seq(rjs)
@@ -13,7 +14,8 @@ val checkCdn = taskKey[Unit]("Check the CDN")
 checkCdn := {
   if (RjsKeys.paths.value != Map(
     "myunderscore" -> ("lib/underscorejs/underscore", "http://cdn.jsdelivr.net/webjars/underscorejs/1.6.0-1/underscore-min"),
-    "myknockout" -> ("lib/knockout/knockout", "http://cdn.jsdelivr.net/webjars/knockout/2.3.0/knockout")
+    "myknockout" -> ("lib/knockout/knockout", "http://cdn.jsdelivr.net/webjars/knockout/2.3.0/knockout"),
+    "myjquery" -> ("lib/jquery/jquery", "http://cdn.jsdelivr.net/webjars/jquery/1.11.1/jquery.min")
   )) {
     sys.error(s"${RjsKeys.paths.value} is not what we expected")
   }

--- a/src/sbt-test/sbt-rjs-plugin/rjs/src/main/assets/javascripts/main.js
+++ b/src/sbt-test/sbt-rjs-plugin/rjs/src/main/assets/javascripts/main.js
@@ -1,7 +1,8 @@
 requirejs.config({
     paths: {
         'myunderscore': '../lib/underscorejs/underscore',
-        myknockout: '../lib/knockout/knockout'
+        myknockout: '../lib/knockout/knockout',
+        "myjquery": "../lib/jquery/jquery"
     },
     shim: {
         'underscore': {


### PR DESCRIPTION
Since the WebJar path calculation only uses `libraryDependencies` to find the group ids of webjars, the CDN substitution doesn't work for webjars that are transitive dependencies.
