### PR TITLE
Load CNDied Webjars dependencies over HTTPS

### DIFF
--- a/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
+++ b/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
@@ -70,7 +70,7 @@ object SbtRjs extends AutoPlugin {
     removeCombined := true,
     resourceManaged in rjs := webTarget.value / rjs.key.label,
     rjs := runOptimizer.dependsOn(webJarsNodeModules in Plugin).value,
-    webJarCdns := Map("org.webjars" -> "http://cdn.jsdelivr.net/webjars")
+    webJarCdns := Map("org.webjars" -> "//cdn.jsdelivr.net/webjars")
   )
 
 


### PR DESCRIPTION
I figured out that the default configuration is not working when used in HTTPS context.

By default the dependencies are linked to an HTTP resource (eg: https://cdn.jsdelivr.net/webjars/xx/yy/zz.min.js), and the browers forbid to fetch an insecure file in HTTPS.

This PR just ensure that dependencies are always loaded in https (works in http & https).
If for any reason you don't want that, I recommend to explicitly describe this tricks in the documentation.
