### PR TITLE
Remove protocol from CDN address to enable SSL on secure servers

### DIFF
--- a/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
+++ b/src/main/scala/com/typesafe/sbt/rjs/SbtRjs.scala
@@ -70,7 +70,7 @@ object SbtRjs extends AutoPlugin {
     removeCombined := true,
     resourceManaged in rjs := webTarget.value / rjs.key.label,
     rjs := runOptimizer.dependsOn(webJarsNodeModules in Plugin).value,
-    webJarCdns := Map("org.webjars" -> "http://cdn.jsdelivr.net/webjars")
+    webJarCdns := Map("org.webjars" -> "//cdn.jsdelivr.net/webjars")
   )
 
 

--- a/src/sbt-test/sbt-rjs-plugin/rjs/build.sbt
+++ b/src/sbt-test/sbt-rjs-plugin/rjs/build.sbt
@@ -13,9 +13,9 @@ val checkCdn = taskKey[Unit]("Check the CDN")
 
 checkCdn := {
   if (RjsKeys.paths.value != Map(
-    "myunderscore" -> ("lib/underscorejs/underscore", "http://cdn.jsdelivr.net/webjars/underscorejs/1.6.0-1/underscore-min"),
-    "myknockout" -> ("lib/knockout/knockout", "http://cdn.jsdelivr.net/webjars/knockout/2.3.0/knockout"),
-    "myjquery" -> ("lib/jquery/jquery", "http://cdn.jsdelivr.net/webjars/jquery/1.11.1/jquery.min")
+    "myunderscore" -> ("lib/underscorejs/underscore", "//cdn.jsdelivr.net/webjars/underscorejs/1.6.0-1/underscore-min"),
+    "myknockout" -> ("lib/knockout/knockout", "//cdn.jsdelivr.net/webjars/knockout/2.3.0/knockout"),
+    "myjquery" -> ("lib/jquery/jquery", "//cdn.jsdelivr.net/webjars/jquery/1.11.1/jquery.min")
   )) {
     sys.error(s"${RjsKeys.paths.value} is not what we expected")
   }


### PR DESCRIPTION
This does the same as https://github.com/sbt/sbt-rjs/pull/40 but also removes the "http:" from the tests, so it should easily merged. Thank you for your work, and please consider accepting this as soon as possible.
